### PR TITLE
Support for multiple keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,18 @@ datacenters:
     port: 8200
   - name: consulserver-2.example.dc1.com
     port: 8200
-  key: <key>
+  keys:
+  - key: <key1>
+  - key: <key2>
   name: dc1
 - hosts:
   - name: consulserver-1.example.dc2.com
     port: 8200
   - name: consulserver-2.example.dc2.com
     port: 8200
-  key: <key>
+  keys:
+  - key: <key1>
+  - key: <key2>
   name: dc2
 ```
 
@@ -62,8 +66,9 @@ This can be converted to JSON or HCL as needed. Configuration options available 
  - `capath` - String - The path to a directory containing CA certificates for all Vaults
  - `datacenters` - Array of maps - an array of datacenters with nested options
    - `name` - String - The name of the datacenters
-   - `key` - String - The unseal key for that datacenter. Should be base64 encoded if the `gpg` flag is set to true
-   - `hosts` - Array - contains three config options:
+   - `keys` - Array - contains keys:
+     - `key` - String - The unseal key for that datacenter. Should be base64 encoded if the `gpg` flag is set to true
+   - `hosts` - Array - contains two config options:
      - `name` - String - Hostname of a Vault server
      - `port` - Int - The port that Vault server listens on
 
@@ -86,6 +91,3 @@ If you want to contribute, we use [glide](https://glide.sh/) for dependency mana
  - cloning this repo into `$GOPATH/src/github.com/jaxxstorm/hookpick`
  - run `glide install` from the directory
  - run `go build -o hookpick main.go`
-
-
-

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,8 +39,6 @@ var datacenter string
 
 var datacenters []config.Datacenter
 
-var hosts []config.Host
-
 // Version : This is for the Version command
 var Version string
 

--- a/config/types.go
+++ b/config/types.go
@@ -2,11 +2,15 @@ package config
 
 type Datacenter struct {
 	Name  string
-	Key   string
+	Keys  []Key
 	Hosts []Host
 }
 
 type Host struct {
 	Name string
 	Port int
+}
+
+type Key struct {
+	Key string
 }

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ package main
 
 import "github.com/jaxxstorm/hookpick/cmd"
 
-var Version = "v0.0.1"
+var Version = "v0.0.2"
 
 func main() {
 	cmd.Execute(Version)


### PR DESCRIPTION
This PR introduce support for multiple keys. The config structure is a bit different now:

```
  keys:
  - key: <key1>
  - key: <key2>
```
Where each `key` line provides a single key (gpg or plain text)

Example:
```
gpg: false
datacenters:
- hosts:
  - name: vault1.test
    port: 8200
  - name: vault2.test
    port: 8200
  - name: vault3.test
    port: 8200
  keys:
  - key: oJLvra8jHVbrjgSvudT9L2N8H9hz5TQ3lCXfclCQDLqm
  - key: h4jg+tSLI2L9RctbrbFC/JJTwkMBStFjMkHv5qso2I9D
  - key: IQXWLnEkBmNIP1D35Xir9iwsDQKOCie5WHsPkTEuPX21
  - key: Pp9lCx93AkzgZu7Vs2svy5bm/BhKP8sdxxfHOKDMZi1Z
  - key: 15kWjOLypUDdaABE/nCvs9/UzzlUEs/SCTQrakLkthld
  name: dc
```

Tested scenarios:
- unseal Vault cluster (GPG/plain text keys)
- rekey Vault

This PR fix https://github.com/jaxxstorm/hookpick/issues/18