### PR TITLE
Osx gpg agent mods

### DIFF
--- a/gpg/decrypt.go
+++ b/gpg/decrypt.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"fmt"
+	log "github.com/Sirupsen/logrus"
 	"os/exec"
 )
 
@@ -28,7 +28,7 @@ func gpg_major_version() (int, error) {
 	var err error
 
 	if cmdOut, err = exec.Command(cmdName, cmdArgs...).Output(); err != nil {
-		fmt.Println("There was an error running gpg --version: ", err)
+		log.Fatal("There was an error running gpg --version: ", err)
 		return -1, err
 	}
 	gpgvers := string(cmdOut)
@@ -70,18 +70,18 @@ func Decrypt(key string) (string, error) {
 
 	gpgvers, err = gpg_major_version()
 	if err != nil {
-		fmt.Println(err)
-		fmt.Println("Due to error determining gpg version, defaulting to gpg vers 1 options")
+		log.Warn(err)
+		log.Warn("Due to error determining gpg version, defaulting to gpg vers 1 options")
 		gpgvers = 1
 	}
 
 	cmd.Path = gpgCmd
 	if gpgvers == 1 {
-		fmt.Println("Using GPG decrypt for GPG version 1")
+		log.Debug("Using GPG decrypt for GPG version 1")
 		cmd.Args = []string{"--decrypt", "--quiet"}
 	}
 	if gpgvers == 2 {
-		fmt.Println("Using GPG decrypt for GPG version 2")
+		log.Debug("Using GPG decrypt for GPG version 2")
 		cmd.Args = []string{"--decrypt", "--quiet", "--pinentry-mode", "loopback"}
 	}
 	dec, err := base64.StdEncoding.DecodeString(key)

--- a/gpg/decrypt.go
+++ b/gpg/decrypt.go
@@ -14,6 +14,12 @@ type GPGHelper struct {
 	Decrypt StringDecrypter
 }
 
+func NewGPGHelper(decrypter StringDecrypter) *GPGHelper {
+	return &GPGHelper{
+		Decrypt: decrypter,
+	}
+}
+
 func gpg_major_version() (int, error) {
 	cmdName := "gpg"
 	cmdArgs := []string{"--version"}
@@ -47,13 +53,6 @@ func gpg_major_version() (int, error) {
 		}
 	}
 	return -1, errors.New("Could not determine gpg major version")
-}
-
-func NewGPGHelper(decrypter StringDecrypter) *GPGHelper {
-	return &GPGHelper{
-		Decrypt: decrypter,
-	}
-
 }
 
 // Decrypt GPG keys

--- a/gpg/decrypt.go
+++ b/gpg/decrypt.go
@@ -3,14 +3,52 @@ package gpg
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"os/exec"
 )
+
+func gpg_major_version() (int, error) {
+	cmdName := "gpg"
+	cmdArgs := []string{"--version"}
+
+	var cmdOut []byte
+	var err error
+
+	if cmdOut, err = exec.Command(cmdName, cmdArgs...).Output(); err != nil {
+		fmt.Println("There was an error running gpg --version: ", err)
+		return -1, err
+	}
+	gpgvers := string(cmdOut)
+
+	// gpg1 --version output should look similar to
+	//
+	//	gpg (GnuPG) 1.4.20
+	//	Copyright (C) 2015 Free Software Foundation, Inc.
+	//...
+
+	// gpg2 --version
+	//	gpg (GnuPG) 2.2.5
+	//	libgcrypt 1.8.2
+	//	Copyright (C) 2018 Free Software Foundation, Inc.
+
+	for i := 0; i < len(gpgvers); i++ {
+		if gpgvers[i] == '1' {
+			return 1, nil
+		}
+		if gpgvers[i] == '2' {
+			return 2, nil
+		}
+	}
+	return -1, errors.New("Could not determine gpg major version")
+}
 
 // Decrypt GPG keys
 func Decrypt(key string) (string, error) {
 
 	var cmd exec.Cmd
 	var output bytes.Buffer
+	var gpgvers int
 
 	gpgCmd, err := exec.LookPath("gpg")
 
@@ -18,9 +56,22 @@ func Decrypt(key string) (string, error) {
 		return "", err
 	}
 
-	cmd.Path = gpgCmd
-	cmd.Args = []string{"--decrypt", "--quiet"}
+	gpgvers, err = gpg_major_version()
+	if err != nil {
+		fmt.Println(err)
+		fmt.Println("Due to error determining gpg version, defaulting to gpg vers 1 options")
+		gpgvers = 1
+	}
 
+	cmd.Path = gpgCmd
+	if gpgvers == 1 {
+		fmt.Println("Using GPG decrypt for GPG version 1")
+		cmd.Args = []string{"--decrypt", "--quiet"}
+	}
+	if gpgvers == 2 {
+		fmt.Println("Using GPG decrypt for GPG version 2")
+		cmd.Args = []string{"--decrypt", "--quiet", "--pinentry-mode", "loopback"}
+	}
 	dec, err := base64.StdEncoding.DecodeString(key)
 	if err != nil {
 		return "", err


### PR DESCRIPTION

Added code to determine if gpg1 or gpg2 is being used and set gpg decrypt arguments accordingly.

Helps reconcile gpg2 decryption error where user never gets prompted for passphrase and hookpick unseal fails with:

 "GPG Decryption Error: exit status 2" 

Tested working on OSX.